### PR TITLE
Adding setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setup(name='trailmap',
+      version='0.0.1',
+      description='Acquisition Pathway Analysis tool for Cyclus',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      author='Katie Mummah',
+      author_email='katiemummah@gmail.com',
+      url='https://github.com/CNERG/trailmap',
+      packages=find_packages()
+      )


### PR DESCRIPTION
A setup file that allows the trailmap directory to be packaged as a pip package. With this file, the user can run `python -m pip install -e . --user` and then can run trailmap

Closes #16 