### PR TITLE
correct import functions from trailmap/

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,6 +1,6 @@
 import argparse
-import parse_input as pi
-import commodity_dictionary as cd
+import trailmap.parse_input as pi
+import trailmap.commodity_dictionary as cd
 
 
 def make_parser():


### PR DESCRIPTION
Should have been included in #17 but didn't get pushed. Required for parse_input and commodity_dictionary to be found by main.py