### PR TITLE
in acquisition path enumeration, accept a str or int as a source and/or sink

### DIFF
--- a/tests/ap_data.py
+++ b/tests/ap_data.py
@@ -16,14 +16,14 @@ testdata = [
      {("Source", "Sink"), ("Source", "Sink")}
      ),
     ("multisourcesink",
-     [("SourceA", "Facility"), ("SourceB", "Facility"), ("Facility", "SinkA"),
-      ("Facility", "SinkB")],
-     {"SourceA": [], "SourceB": [], "Facility": ["commodityA", "commodityB"],
-      "SinkA": ["changedcommodity"], "SinkB": ["changedcommodity"]},
-     {"SourceA": ["commodityA"], "SourceB": ["commodityB"],
-      "Facility": ["changedcommodity"], "SinkA": [], "SinkB": []},
-     {("SourceA", "Facility", "SinkA"), ("SourceA", "Facility", "SinkB"),
-      ("SourceB", "Facility", "SinkA"), ("SourceB", "Facility", "SinkB")}
+     [("Source", "Facility"), ("Source1", "Facility"), ("Facility", "Sink"),
+      ("Facility", "Sink1")],
+     {"Source": [], "Source1": [], "Facility": ["commodityA", "commodityB"],
+      "Sink": ["changedcommodity"], "Sink1": ["changedcommodity"]},
+     {"Source": ["commodityA"], "Source1": ["commodityB"],
+      "Facility": ["changedcommodity"], "Sink": [], "Sink1": []},
+     {("Source", "Facility", "Sink"), ("Source", "Facility", "Sink1"),
+      ("Source1", "Facility", "Sink"), ("Source1", "Facility", "Sink1")}
      ),
     ("bypass",
      [("Source", "Facility"), ("Source", "Sink"), ("Facility", "Sink")],
@@ -33,12 +33,12 @@ testdata = [
      {("Source", "Sink"), ("Source", "Facility", "Sink")}
      ),
     ("independent",
-     [("SourceA", "SinkA"), ("SourceB", "SinkB")],
-     {"SourceA": [], "SourceB": [], "SinkA": ["commodityA"],
-      "SinkB": ["commodityB"]},
-     {"SourceA": ["commodityA"], "SourceB": ["commodityB"], "SinkA": [],
-      "SinkB": []},
-     {("SourceA", "SinkA"), ("SourceB", "SinkB")}
+     [("Source", "Sink"), ("Source1", "Sink1")],
+     {"Source": [], "Source1": [], "Sink": ["commodityA"],
+      "Sink1": ["commodityB"]},
+     {"Source": ["commodityA"], "Source1": ["commodityB"], "Sink": [],
+      "Sink1": []},
+     {("Source", "Sink"), ("Source1", "Sink1")}
      ),
     ("cycle",
      [("Source", "Facility"), ("Facility", "Recycle"), ("Recycle", "Facility"),

--- a/tests/test_acquisition_paths.py
+++ b/tests/test_acquisition_paths.py
@@ -35,6 +35,58 @@ def test_find_simple_paths(name, edges, fd_in, fd_out, exp_paths):
     assert exp_paths == obs_pathways
 
 
+def test_find_simple_paths_str_sources():
+    G = nx.MultiDiGraph()
+    edges = [("A","B"), ("B","C")]
+    G.add_edges_from(edges)
+    sources = "A"
+    sinks = ["B"]
+    exp_paths = {("A", "B", "C")}
+
+    obs_pathways = ap.find_simple_paths(G, sources, sinks)
+
+    assert exp_paths == obs_pathways
+
+
+def test_find_simple_paths_str_sinks():
+    G = nx.MultiDiGraph()
+    edges = [("Source","A"), ("A","B"), ("B","C"), ("B","Sink"), ("C","A")]
+    G.add_edges_from(edges)
+    sources = ["Source"]
+    sinks = "Sink"
+    exp_paths = {("Source","A","B","Sink")}
+
+    obs_pathways = ap.find_simple_paths(G, sources, sinks)
+
+    assert exp_paths == obs_pathways
+
+
+def test_find_simple_paths_int_sources():
+    G = nx.MultiDiGraph()
+    edges = [(0,1), (1,2), (2,3), (2,4), (3,1)]
+    G.add_edges_from(edges)
+    sources = 0
+    sinks = [4]
+
+    exp_paths = {(0, 1, 2, 4)}
+    obs_pathways = ap.find_simple_paths(G, sources, sinks)
+
+    assert exp_paths == obs_pathways
+
+
+def test_find_simple_paths_int_sinks():
+    G = nx.MultiDiGraph()
+    edges = [(0,1), (1,2), (2,3), (2,4), (3,1)]
+    G.add_edges_from(edges)
+    sources = [0]
+    sinks = 4
+
+    exp_paths = {(0, 1, 2, 4)}
+    obs_pathways = ap.find_simple_paths(G, sources, sinks)
+
+    assert exp_paths == obs_pathways
+
+
 @pytest.mark.parametrize("name, edges, fd_in, fd_out, exp_paths", testdata)
 def test_apa(name, edges, fd_in, fd_out, exp_paths):
     (G, obs_paths) = ap.conduct_apa(fd_in, fd_out)

--- a/tests/test_acquisition_paths.py
+++ b/tests/test_acquisition_paths.py
@@ -40,7 +40,7 @@ def test_find_simple_paths_str_sources():
     edges = [("A","B"), ("B","C")]
     G.add_edges_from(edges)
     sources = "A"
-    sinks = ["B"]
+    sinks = ["C"]
     exp_paths = {("A", "B", "C")}
 
     obs_pathways = ap.find_simple_paths(G, sources, sinks)

--- a/trailmap/acquisition_paths.py
+++ b/trailmap/acquisition_paths.py
@@ -30,6 +30,12 @@ def build_graph(facility_dict_in, facility_dict_out):
 def find_simple_paths(G, sources, sinks):
     ''' finds all simple paths between a given list of sources and targets
     '''
+    # turn sources/sinks into list if a single string/int was submitted
+    if type(sources) == int or type(sources) == str:
+        sources = [sources]
+    if type(sinks) == int or type(sinks) == str:
+        sinks = [sinks]
+
     pathways = set()
     for source, sink in [(x, y) for x in sources for y in sinks]:
         pathways.update({tuple(path) for path in nx.all_simple_paths(


### PR DESCRIPTION
This PR makes a small change to `find_simple_paths` to check if the user submitted a string/int like `"Source"` or `0` as a source and/or sink to enumerate pathways between, and if so, converts it to the desired type, list (such as `["Source"]`). Additional tests accompany this modification as well as a slight update to the testing data.