### PR TITLE
Add Dockerhub authentication

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   test_py3:
     docker:
       - image: cyclus/cycamore:latest
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASS
     steps:
       - checkout
       - run: pip install -U pytest networkx matplotlib scipy coverage
@@ -16,3 +19,4 @@ workflows:
   testing:
     jobs:
       - test_py3
+          context: dockerhub

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,5 @@ jobs:
 workflows:
   testing:
     jobs:
-      - test_py3
+      - test_py3:
           context: dockerhub


### PR DESCRIPTION
Ensures CircleCI can pull the relevant docker image by adding the dockerhub context