### PR TITLE
no code coverage on print function

### DIFF
--- a/trailmap/acquisition_paths.py
+++ b/trailmap/acquisition_paths.py
@@ -44,7 +44,7 @@ def find_simple_paths(G, sources, sinks):
     return pathways
 
 
-def print_acquisition_paths(pathways):
+def print_acquisition_paths(pathways): # pragma: no cover
     print("\nSimple paths")
     pprint(pathways)
 


### PR DESCRIPTION
Don't run code coverage on `print_acquisition_paths`, which is just a print function