### PR TITLE
simplify commodity dictionary and add testing

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -17,6 +17,8 @@ def make_parser():
                    default='trailmap.gpickle',
                    help='output path for pickled graph')
     p.add_argument('--supress-print', '-sp', action='store_true')
+    p.add_argument('--metadata', '-m', nargs=1, help='Cyclus metadata file',
+                   type=argparse.FileType('r'))
 
     return p
 
@@ -26,7 +28,12 @@ def main(args=None):
     p = make_parser()
     ns = p.parse_args(args=args)
 
-    commodity_dictionary = cd.build_commod_dictionary()
+    if ns.metadata:
+        m = ns.metadata[0]
+        print(m["specs"])
+        commodity_dictionary = cd.build_commod_dictionary(ns.metadata[0])
+    else:
+        commodity_dictionary = cd.build_commod_dictionary()
     (facility_dict_in,
     facility_dict_out) = pi.parse_input(ns.infile[0], commodity_dictionary)
     (G, pathways) = ap.conduct_apa(facility_dict_in, facility_dict_out)

--- a/tests/test_commodity_dictionary.py
+++ b/tests/test_commodity_dictionary.py
@@ -22,3 +22,40 @@ def test_commod_names_outcomodity():
     assert ['fuel_outcommods'] == cd.get_commod_names(metadata["annotations"],
                                                       "outcommodity",
                                                       ":cycamore:Reactor")
+
+
+def test_build_facility_dictionary():
+    exp = {':agents:KFacility': (['in_commod'], ['out_commod']),
+           ':agents:NullInst': ([], []),
+           ':agents:NullRegion': ([], []),
+           ':agents:Predator': (['prey'], ['commod']),
+           ':agents:Prey': ([], ['commod']),
+           ':agents:Sink': (['in_commods'], []),
+           ':agents:Source': ([], ['commod']),
+           ':cycamore:DeployInst': ([], []),
+           ':cycamore:Enrichment': (['feed_commod'], ['product_commod',
+                                     'tails_commod']),
+           ':cycamore:FuelFab': (['fill_commods', 'fiss_commods',
+                                  'topup_commod'], ['outcommod']),
+           ':cycamore:GrowthRegion': ([], []),
+           ':cycamore:ManagerInst': ([], []),
+           ':cycamore:Mixer': ([], ['out_commod']),
+           ':cycamore:Reactor': (['fuel_incommods', 'pref_change_commods',
+                                  'recipe_change_commods'],
+                                 ['fuel_outcommods']),
+           ':cycamore:Separations': (['feed_commods'], ['leftover_commod',
+                                      'streams_']),
+           ':cycamore:Sink': (['in_commods'], []),
+           ':cycamore:Source': ([], ['outcommod']),
+           ':cycamore:Storage': (['in_commods'], ['out_commods'])}
+
+    assert cd.build_facility_dictionary(metadata, specs) == exp
+
+
+def test_build_facility_dictionary_subset():
+    archetypes = [':cycamore:Sink', ':cycamore:Source', ':cycamore:Storage']
+    exp = {':cycamore:Sink': (['in_commods'], []), 
+           ':cycamore:Source': ([], ['outcommod']),
+            ':cycamore:Storage': (['in_commods'], ['out_commods'])}
+
+    assert cd.build_facility_dictionary(metadata, archetypes) == exp

--- a/tests/test_commodity_dictionary.py
+++ b/tests/test_commodity_dictionary.py
@@ -59,3 +59,4 @@ def test_build_facility_dictionary_subset():
             ':cycamore:Storage': (['in_commods'], ['out_commods'])}
 
     assert cd.build_facility_dictionary(metadata, archetypes) == exp
+    

--- a/trailmap/commodity_dictionary.py
+++ b/trailmap/commodity_dictionary.py
@@ -4,7 +4,7 @@ import json
 import cyclus
 
 
-def build_commod_dictionary():
+def build_commod_dictionary(): #pragma: no cover
     '''Find all Cyclus archetypes and their commodity tags.
 
     outputs:
@@ -12,7 +12,9 @@ def build_commod_dictionary():
         and the names of their incommodities and outcommodities
     '''
     metadata = cyclus.lib.discover_metadata_in_cyclus_path()
-    archetype_commods = build_facility_dictionary(metadata)
+
+    archetypes = metadata["specs"]    
+    archetype_commods = build_facility_dictionary(metadata, archetypes)
 
     return archetype_commods
 
@@ -40,21 +42,11 @@ def get_commod_names(metadata, uitype, agent):
     return aliases
 
 
-def commodity_aliases(data, aliases):
-    '''Search for addional commodity aliases.'''
-    if isinstance(data, cyclus.jsoncpp.Value):
-        aliases.extend(data)
-    elif isinstance(data, str):
-        aliases.append(data)
-
-    return aliases
-
-
-def build_facility_dictionary(metadata):
+def build_facility_dictionary(metadata, archetypes):
     '''Identify commodities for each available archetype'''
     archetype_commods = {}
 
-    for archetype in metadata["specs"]:
+    for archetype in archetypes:
         incommods = get_commod_names(metadata["annotations"], "incommodity",
                                      archetype)
         outcommods = get_commod_names(metadata["annotations"], "outcommodity",

--- a/trailmap/commodity_dictionary.py
+++ b/trailmap/commodity_dictionary.py
@@ -4,14 +4,18 @@ import json
 import cyclus
 
 
-def build_commod_dictionary(): #pragma: no cover
+def build_commod_dictionary(metadata_file = None): #pragma: no cover
     '''Find all Cyclus archetypes and their commodity tags.
 
     outputs:
     - archetype_commods: a dictionary with the Cyclus archetypes available
         and the names of their incommodities and outcommodities
     '''
-    metadata = cyclus.lib.discover_metadata_in_cyclus_path()
+    if metadata_file is None:
+        print('generating metadata')
+        metadata = cyclus.lib.discover_metadata_in_cyclus_path()
+    else: 
+        metadata = json.load(metadata_file)
 
     archetypes = metadata["specs"]    
     archetype_commods = build_facility_dictionary(metadata, archetypes)


### PR DESCRIPTION
- Took out the extra aliases code (don't use, no plans to add that capability any time soon)
- allowed `facility_dictionary` to produce a commodity dictionary using a given list of archetypes instead of always using the full metadata