### PR TITLE
check pathway length without removing item from set, remove extra print statement

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -31,7 +31,6 @@ def main(args=None):
 
     if ns.metadata:
         m = ns.metadata[0]
-        print(m["specs"])
         commodity_dictionary = cd.build_commod_dictionary(ns.metadata[0])
     else:
         commodity_dictionary = cd.build_commod_dictionary()

--- a/trailmap/pathway_analysis.py
+++ b/trailmap/pathway_analysis.py
@@ -14,13 +14,12 @@ def print_graph_parameters(G, pathways): # pragma: no cover
     print("A total of " + str(num_paths) + " pathways were generated")
 
     shortest = get_shortest_path(pathways)
-
     longest = get_longest_path(pathways)
 
-    print("\nThe shortest pathway is length " + str(shortest_length))
-    print("pathways with this length are " + str(len(shortest.pop())))
+    print("\nThe shortest pathway is length " + str(len(next(iter(shortest)))))
+    print("pathways with this length are " + str(shortest))
 
-    print("\nGraph depth is " + str(len(longest.pop())))
+    print("\nGraph depth is " + str(len(next(iter(longest)))))
     print("pathways with this length are " + str(longest))
 
     semiconnected = nx.is_semiconnected(G)


### PR DESCRIPTION
Corrects a few things that were missed in #34 

Removes extra print statement that was in `scripts/main.py`

Finds the longest and shortest pathways without losing one

- Printing the shortest/longest length was popping an item from a set to get the length, which then removes that item from the set. 
- When the list of pathways with longest/shortest length is printed after this action, one item is missing
- Fixed by changing to len(next(iter(set_of_pathways()))) which does not remove the item